### PR TITLE
Skipped email success/failure

### DIFF
--- a/includes/submission.php
+++ b/includes/submission.php
@@ -241,6 +241,9 @@ class WPCF7_Submission {
 		$skip_mail = apply_filters( 'wpcf7_skip_mail', $skip_mail, $contact_form );
 
 		if ( $skip_mail ) {
+			if(isset($contact_form->is_success) && !$contact_form->is_success){
+				return false;
+			}
 			return true;
 		}
 


### PR DESCRIPTION
Allows adding state to skipped email, since we might be skipping the email to store data in DB, or send it through an API, those actions might fail, so we are providing a way to state this.

Example usage:

``` php
add_action('wpcf7_before_send_mail','actionBeforeSend',10,1);
function actionBeforeSend($cf){
 $cf->skip_mail = true;
  /**
   * Some logic for doing something with the posted data...
   * Ex: Save it to db, send it to API...
   */
  if($result){
    $cf->is_success = true;
  }else{
    $cf->is_success = false;
  }
  return $cf;
}
```
